### PR TITLE
Add search defaults to simpleldap.Connection class

### DIFF
--- a/simpleldap/__init__.py
+++ b/simpleldap/__init__.py
@@ -168,7 +168,7 @@ class Connection(object):
         """
         self._search_defaults.update(kwargs)
 
-    def reset_search_defaults(self, args):
+    def reset_search_defaults(self, args=None):
         """
         Unset defaults that might have been set by set_search_defaults
 
@@ -176,7 +176,7 @@ class Connection(object):
         conn.reset_search_defaults(['scope'])
         """
 
-        if args == '*':
+        if args is None:
             self._search_defaults = {}
         else:
             for arg in args:

--- a/simpleldap/__init__.py
+++ b/simpleldap/__init__.py
@@ -168,12 +168,12 @@ class Connection(object):
         """
         self._search_defaults.update(kwargs)
 
-    def reset_search_defaults(self, args=None):
+    def clear_search_defaults(self, args=None):
         """
         Unset defaults that might have been set by set_search_defaults
 
         conn.set_search_defaults(scope=ldap.SCOPE_BASE)
-        conn.reset_search_defaults(['scope'])
+        conn.clear_search_defaults(['scope'])
         """
 
         if args is None:

--- a/simpleldap/__init__.py
+++ b/simpleldap/__init__.py
@@ -158,21 +158,21 @@ class Connection(object):
             self.connection.start_tls_s()
         self.connection.simple_bind_s(dn, password)
 
-    def search_defaults(self, **kwargs):
+    def set_search_defaults(self, **kwargs):
         """
         Set defaults for search.
 
-        conn.search_defaults(basedn='dc=example,dc=com', timeout=100)
-        conn.search_defaults(attrs=['cn'], scope=ldap.SCOPE_BASE)
+        conn.set_search_defaults(basedn='dc=example,dc=com', timeout=100)
+        conn.set_search_defaults(attrs=['cn'], scope=ldap.SCOPE_BASE)
 
         """
         self._search_defaults.update(kwargs)
 
     def reset_search_defaults(self, args):
         """
-        Unset defaults that might have been set by search_defaults
+        Unset defaults that might have been set by set_search_defaults
 
-        conn.search_defaults(scope=ldap.SCOPE_BASE)
+        conn.set_search_defaults(scope=ldap.SCOPE_BASE)
         conn.reset_search_defaults(['scope'])
         """
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -100,6 +100,8 @@ class ConnectionTests(TestCase):
         obj = conn.search(**kwargs)[0]
         self.assertEqual(len(obj), 1)
         self.assertTrue('cn' in obj)
+        conn.reset_search_defaults('*')
+        self.assertEqual(conn._search_defaults, {})
 
     def test_get(self):
         conn = simpleldap.Connection('ldap.ucdavis.edu')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -88,15 +88,15 @@ class ConnectionTests(TestCase):
 
     def test_search_defaults(self):
         conn = simpleldap.Connection('ldap.ucdavis.edu')
-        conn.search_defaults(base_dn='ou=Groups,dc=ucdavis,dc=edu')
-        conn.search_defaults(limit=1)
+        conn.set_search_defaults(base_dn='ou=Groups,dc=ucdavis,dc=edu')
+        conn.set_search_defaults(limit=1)
         self.assertRaises(ldap.SIZELIMIT_EXCEEDED, conn.search, 'cn=*')
         kwargs = {'filter': 'cn=External Anonymous', }
         conn.reset_search_defaults(['limit'])
         # Should return all attrs.
         self.assertTrue(len(conn.search(**kwargs)[0]) > 2)
         # Should return just cn attr.
-        conn.search_defaults(attrs=['cn'])
+        conn.set_search_defaults(attrs=['cn'])
         obj = conn.search(**kwargs)[0]
         self.assertEqual(len(obj), 1)
         self.assertTrue('cn' in obj)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -92,7 +92,7 @@ class ConnectionTests(TestCase):
         conn.set_search_defaults(limit=1)
         self.assertRaises(ldap.SIZELIMIT_EXCEEDED, conn.search, 'cn=*')
         kwargs = {'filter': 'cn=External Anonymous', }
-        conn.reset_search_defaults(['limit'])
+        conn.clear_search_defaults(['limit'])
         # Should return all attrs.
         self.assertTrue(len(conn.search(**kwargs)[0]) > 2)
         # Should return just cn attr.
@@ -100,7 +100,7 @@ class ConnectionTests(TestCase):
         obj = conn.search(**kwargs)[0]
         self.assertEqual(len(obj), 1)
         self.assertTrue('cn' in obj)
-        conn.reset_search_defaults()
+        conn.clear_search_defaults()
         self.assertEqual(conn._search_defaults, {})
 
     def test_get(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -100,7 +100,7 @@ class ConnectionTests(TestCase):
         obj = conn.search(**kwargs)[0]
         self.assertEqual(len(obj), 1)
         self.assertTrue('cn' in obj)
-        conn.reset_search_defaults('*')
+        conn.reset_search_defaults()
         self.assertEqual(conn._search_defaults, {})
 
     def test_get(self):


### PR DESCRIPTION
Adding these search defaults makes searching as simple as it should be:
all that is required in client code is the LDAP filter string, when
given a connection.

After all of the tedious setup that is required for making the initial
LDAP connection (which simpleldap takes care of), my next biggest
irriation with using the LDAP API is having to continually pass in the
parameters which rarely change with the same connection, such as base
DN. This results in extra global context that needs to be passed in to
otherwise self-contained code.
