### PR TITLE
Expose ldap's compare_s method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,3 +47,14 @@ simple::
 
     with simpleldap.Connection('directory.example.com') as conn:
         is_valid = conn.authenticate('uid=myuser,dc=directory,dc=example,dc=com', 'password')
+
+LDAP also offers a feature to compare an attribute's value with a given string.
+This can occasionally be more efficient and expressive than grabbing an entire
+object from the LDAP store. ``simpleldap`` offers a ``compare`` method for this
+feature::
+
+    >>> conn = simpleldap.Connection('directory.example.com')
+    >>> user_dn = 'uid=myuser,dc=directory,dc=example,dc=com'
+    >>> conn.compare(user_dn, 'cn', 'Joe Smith')
+    True
+

--- a/simpleldap/__init__.py
+++ b/simpleldap/__init__.py
@@ -272,3 +272,11 @@ class Connection(object):
             return False
         else:
             return True
+
+    def compare(self, dn, attr, value):
+        """
+        Convenience method for ldap's "compare" family of function, which
+        return a boolean value to indicate whether the `dn` object's `attr`
+        contains `value` or not.
+        """
+        return self.connection.compare_s(dn, attr, value) == 1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -115,6 +115,11 @@ class ConnectionTests(TestCase):
         self.assertRaises(simpleldap.MultipleObjectsFound, conn.get, 'cn=*',
                           base_dn='ou=Groups,dc=ucdavis,dc=edu')
 
+    def test_compare(self):
+        conn = simpleldap.Connection('ldap.ucdavis.edu')
+        obj = conn.get('cn=External Anonymous',
+                       base_dn='ou=Groups,dc=ucdavis,dc=edu')
+        self.assert_(conn.compare(obj.dn, 'cn', 'External Anonymous'))
 
 class AuthenticateTests(TestCase):
 


### PR DESCRIPTION
Hi there -- Great module! I was planning on writing a module that did exactly this (ldap for humans, basically) but you beat me to it. I wanted to at least add a little something though, so here is a method that lets you use ldap's compare_s method in a slightly more pythonic way, returning an actual boolean value rather than 0 or 1.
