### PR TITLE
Upgrade to Python 3 (and keep compatibility with Python 2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,16 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Topic :: System :: Systems Administration :: Authentication/Directory',
     'Topic :: System :: Systems Administration :: Authentication/Directory :: LDAP',
 ]
 
 setup(
     name="simpleldap",
-    version="0.8",
+    version="0.9",
     description="A module that makes simple LDAP usage simple.",
     long_description=open('README.rst').read(),
     keywords="ldap simple simpleldap",
@@ -27,6 +30,6 @@ setup(
     url="https://github.com/gdub/python-simpleldap",
     license="MIT",
     packages=["simpleldap"],
-    install_requires=["python-ldap"],
-    tests_require=["tox", "pytest", "pep8", "python-ldap"],
+    install_requires=["pyldap"],
+    tests_require=["tox", "pytest", "pep8", "pyldap"],
 )

--- a/simpleldap/__init__.py
+++ b/simpleldap/__init__.py
@@ -50,7 +50,7 @@ class LDAPItem(cidict):
         self.dn, self.attributes = result
         # XXX: quick and dirty, should really proxy straight to the existing
         # self.attributes dict.
-        for attribute, values in self.attributes.iteritems():
+        for attribute, values in self.attributes.items():
             # Make the entire list of values for each LDAP attribute
             # accessible through a dictionary mapping.
             self[attribute] = values
@@ -168,7 +168,7 @@ class Connection(object):
         else:
             self.connection = ldap.initialize(uri)
         if options:
-            for name, value in options.iteritems():
+            for name, value in options.items():
                 self.connection.set_option(getattr(ldap, name), value)
         if encryption == 'tls':
             self.connection.start_tls_s()

--- a/simpleldap/cidict.py
+++ b/simpleldap/cidict.py
@@ -32,7 +32,7 @@ class cidict(dict):
             self[key] = dict[key]
 
     def has_key(self, key):
-        return super(cidict, self).has_key(key.lower())
+        return super(cidict, self).__contains__(key.lower())
 
     __contains__ = has_key
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -25,14 +25,18 @@ class ConnectionTests(TestCase):
                 conn = simpleldap.Connection(hostname=host, port=port,
                                              encryption=method,
                                              require_cert=cert)
-            except Exception, e:
+            except Exception as e:
                 self.fail("Got error connecting to %s %s %s %s: %s"
                           % (host, port, method, cert, e))
             else:
                 conn.close()
 
     def test_initialize_kwargs(self):
-        from StringIO import StringIO
+        try:  # Python 2
+            from StringIO import StringIO
+        except ImportError:  # Python 3
+            from io import StringIO
+
         output = StringIO()
         initialize_kwargs = {'trace_file': output, 'trace_level': 0}
         conn = simpleldap.Connection('ldap.utexas.edu',
@@ -107,7 +111,7 @@ class ConnectionTests(TestCase):
         obj = conn.get('cn=External Anonymous',
                        base_dn='ou=Groups,dc=ucdavis,dc=edu')
         self.assertTrue(isinstance(obj, conn.result_item_class))
-        self.assertEqual(obj['cn'], ['External Anonymous'])
+        self.assertEqual(obj['cn'], [b'External Anonymous'])
 
         self.assertRaises(simpleldap.ObjectNotFound, conn.get,
                           'cn=Does not exist',


### PR DESCRIPTION
By switching from python-ldap to pyldap (which is a fork compatible with Python 2/3 that is well maintained, and offers nearly the exact same API as `python-ldap`), I was able to update the source code to something compatible with both Python 2.6+ and 3.3+.

All tests pass, at least on Python 2.7 and 3.5.
